### PR TITLE
Set up Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,40 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is **Goof** — Snyk's intentionally vulnerable Node.js/Express TODO demo app. There is a single web service (`goof`) at the repo root. It stores TODOs and users in **MongoDB** (required) and has an optional **MySQL** (TypeORM) backend used only by the `/users` routes.
+
+### Services
+
+| Service | Required? | How to run | Notes |
+|---|---|---|---|
+| `goof` web app | yes | `npm run dev` (nodemon) or `npm start` — listens on `http://localhost:3001` | Scripts already set `NODE_OPTIONS=--openssl-legacy-provider`; do not drop this flag (needed by the old dependency stack on modern Node). |
+| MongoDB | yes | container `goof-mongo` on port 27017 (see below) | App connects at boot to `mongodb://localhost/express-todo` and seeds `admin@snyk.io` / `SuperSecretPassword`. Use **Mongo 3.x/4.2** (node `mongodb` driver is `3.5.9`); Mongo 5+ is incompatible. |
+| MySQL | optional | container `goof-mysql` on port 3306 | Only needed for `/users` routes. Creds are hard-coded in `typeorm-db.js` (`root`/`root`, db `acme`). If it is down the app still boots (connection error is caught). |
+
+### Non-obvious startup caveats (important)
+
+- **Docker uses a non-default config here.** This VM's kernel does not support `overlay2` and `iptables`/`nftables` are not installable (Ubuntu archive egress is blocked), so `/etc/docker/daemon.json` is set to `storage-driver: vfs`, `iptables: false`, `bridge: none`. Because of `bridge: none`, **containers must use `--network host`** (port publishing with `-p` does not work). `vfs` is slow/disk-heavy but functional.
+- **Start MongoDB before the app.** The MySQL/TypeORM connection is attempted only once at startup; if you want `/users` to work, start `goof-mysql` and wait for it to be ready **before** starting the app (otherwise restart the app once MySQL is up).
+- Start dockerd (no systemd in this container) if it is not already running: `sudo dockerd &` (logs to your redirect). Then:
+  - `sudo docker run -d --name goof-mongo --network host mongo:3`
+  - `sudo docker run -d --name goof-mysql --network host -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=acme mysql:5`
+- Reset TODOs: `npm run cleanup` (requires a local `mongo` shell; alternatively use the container).
+
+### Lint / test / build
+
+- **Lint:** none configured (no ESLint/Prettier).
+- **Test:** `npm test` runs `snyk test` — a security/dependency scan that needs a Snyk account (`snyk auth`) and network to snyk.io; it is not a functional unit-test suite. The file under `tests/` is a demo spec and is not wired to a runnable test runner.
+- **Build (optional):** `npm run build` (browserify) regenerates `public/js/bundle.js`; not required for the server to boot.
+
+### Quick end-to-end sanity check
+
+```bash
+# login (NoSQL-auth demo) then create a todo
+curl -s -X POST -c cj.txt -H 'Content-Type: application/json' \
+  --data-binary '{"username":"admin@snyk.io","password":"SuperSecretPassword"}' \
+  http://localhost:3001/login -o /dev/null
+curl -s -X POST -b cj.txt --data 'content=hello' http://localhost:3001/create -o /dev/null
+curl -s http://localhost:3001/ | grep hello        # todo shows on homepage
+curl -s http://localhost:3001/users/               # MySQL-backed users route
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for **Goof** (Snyk's vulnerable Node.js/Express TODO demo) and verifies it runs end-to-end in the Cursor Cloud VM.

This PR adds an `AGENTS.md` documenting durable, non-obvious startup caveats for future cloud agents. No application code was changed.

## Environment setup performed

- `npm install` (947 packages; the 146 audit vulnerabilities are expected — this app is intentionally vulnerable).
- Installed Docker 28.5.2 via direct `.deb` downloads (the Ubuntu archive is egress-blocked, so `iptables`/`nftables` deps were skipped). Ran `dockerd` with `storage-driver: vfs`, `iptables: false`, `bridge: none` because the kernel lacks `overlay2` support.
- Started **MongoDB 3** (`goof-mongo`) and **MySQL 5.7** (`goof-mysql`) containers with `--network host`.
- Ran the app in dev mode: `npm run dev` → listening on `http://localhost:3001`.

## Verification (hello-world: create a TODO)

- Homepage renders "Patch TODO List" (HTTP 200).
- NoSQL login as `admin@snyk.io` succeeds (302 → `/admin`).
- Creating a TODO via the UI and via `POST /create` succeeds and the item appears on the homepage.
- MySQL-backed `GET /users/` returns the seeded user `Liran` (HTTP 200).

[goof_add_todo_demo.mp4](https://cursor.com/agents/bc-c37b4ec7-f53e-4253-91dd-6689d5a970bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoof_add_todo_demo.mp4)

[Goof homepage](https://cursor.com/agents/bc-c37b4ec7-f53e-4253-91dd-6689d5a970bc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fgoof_homepage.webp)

## Lint / test

- **Lint:** none configured.
- **Test:** `npm test` runs `snyk test` (security scan; requires `snyk auth`), not a functional test suite.

## Update script

`npm install` (minimal dependency refresh). Service/Docker startup is documented in `AGENTS.md` rather than the update script.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c37b4ec7-f53e-4253-91dd-6689d5a970bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c37b4ec7-f53e-4253-91dd-6689d5a970bc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

